### PR TITLE
Simplify creation of structs

### DIFF
--- a/libs/lsp-primitives/src/lsps0/builders.rs
+++ b/libs/lsp-primitives/src/lsps0/builders.rs
@@ -22,7 +22,6 @@ impl ListprotocolsResponseBuilder {
 
         let result = ListprotocolsResponse {
             protocols,
-            _private: (),
         };
 
         Ok(result)

--- a/libs/lsp-primitives/src/lsps0/schema.rs
+++ b/libs/lsp-primitives/src/lsps0/schema.rs
@@ -4,8 +4,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ListprotocolsResponse {
     pub protocols: Vec<u32>,
-    #[serde(skip_serializing, default)]
-    pub(crate) _private: (),
 }
 
 #[cfg(test)]
@@ -16,7 +14,6 @@ mod test {
     fn serialize_protocol_list() {
         let protocols = ListprotocolsResponse {
             protocols: vec![1, 3],
-            _private: (),
         };
 
         let json_str = serde_json::to_string(&protocols).unwrap();

--- a/libs/lsp-primitives/src/lsps1/builders.rs
+++ b/libs/lsp-primitives/src/lsps1/builders.rs
@@ -53,7 +53,6 @@ impl Lsps1InfoResponseBuilder {
         let result = Lsps1GetInfoResponse {
             website,
             options,
-            _private: (),
         };
 
         Ok(result)
@@ -203,7 +202,6 @@ impl Lsps1OptionsBuilder {
             max_initial_lsp_balance_sat,
             min_channel_balance_sat,
             max_channel_balance_sat,
-            _private: (),
         })
     }
 }
@@ -288,7 +286,6 @@ impl Lsps1CreateOrderRequestBuilder {
             token,
             refund_onchain_address,
             announce_channel,
-            _private: (),
         };
 
         Ok(request)
@@ -424,7 +421,6 @@ impl Lsps1CreateOrderResponseBuilder {
             order_state,
             payment,
             channel,
-            _private: (),
         };
 
         Ok(request)
@@ -463,7 +459,6 @@ impl OnchainPaymentBuilder {
             outpoint,
             sat,
             confirmed,
-            _private: (),
         };
 
         Ok(payment)
@@ -504,7 +499,6 @@ impl Lsps1GetOrderRequestBuilder {
             order_id: self
                 .order_id
                 .context("Missing field 'order_id' in Lsps1GetOrderRequestBuilder")?,
-            _private: (),
         })
     }
 }
@@ -597,7 +591,6 @@ impl PaymentBuilder {
             min_onchain_payment_confirmations: required_onchain_block_confirmations,
             min_fee_for_0conf: minimum_fee_for_0conf,
             onchain_payment,
-            _private: (),
         };
 
         Ok(payment)

--- a/libs/lsp-primitives/src/lsps1/schema.rs
+++ b/libs/lsp-primitives/src/lsps1/schema.rs
@@ -13,8 +13,6 @@ pub struct Lsps1GetInfoResponse {
     pub website: Option<String>,
     pub options: Lsps1Options,
     // Prevents struct initialization. Use Lsps1InfoResponseBuilder instead
-    #[serde(skip_serializing, default)]
-    pub(crate) _private: (),
 }
 
 /// Options returned when calling lsps1.info
@@ -31,9 +29,6 @@ pub struct Lsps1Options {
     pub max_initial_lsp_balance_sat: SatAmount,
     pub min_channel_balance_sat: SatAmount,
     pub max_channel_balance_sat: SatAmount,
-    // Prevents struct initialization. Use Lsps1OptionsBuilder instead
-    #[serde(skip_serializing, default)]
-    pub(crate) _private: (),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -45,9 +40,6 @@ pub struct Lsps1CreateOrderRequest {
     pub token: Option<String>,
     pub refund_onchain_address: Option<OnchainAddress>,
     pub announce_channel: bool,
-    // Prevents struct initialization. Use Lsps1OptionsBuilder instead
-    #[serde(skip_serializing, default)]
-    pub(crate) _private: (),
 }
 
 impl ExpectedFields for Lsps1CreateOrderRequest {
@@ -80,9 +72,6 @@ pub struct Lsps1CreateOrderResponse {
 
     pub payment: Payment,
     pub channel: Option<Channel>,
-    // Prevents struct initialization. Use Lsps1OptionsBuilder instead
-    #[serde(skip_serializing, default)]
-    pub(crate) _private: (),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -112,9 +101,6 @@ pub struct OnchainPayment {
     pub outpoint: String,
     pub sat: SatAmount,
     pub confirmed: bool,
-    // Prevents struct initialization. Use OnchainPaymentBuilder instead
-    #[serde(skip_serializing, default)]
-    pub(crate) _private: (),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -129,10 +115,6 @@ pub struct Payment {
 
     pub min_fee_for_0conf: Option<FeeRate>,
     pub onchain_payment: Option<OnchainPayment>,
-
-    // Prevents struct initialization. Use PaymentBuilder instead
-    #[serde(skip_serializing, default)]
-    pub(crate) _private: (),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -146,8 +128,6 @@ pub struct Channel {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Lsps1GetOrderRequest {
     pub order_id: String,
-    #[serde(skip_serializing, default)]
-    pub(crate) _private: (),
 }
 
 impl ExpectedFields for Lsps1GetOrderRequest {
@@ -224,7 +204,6 @@ mod test {
             token: None,
             refund_onchain_address: Some(onchain),
             announce_channel: false,
-            _private: (),
         };
 
         let _ = serde_json::to_value(request).unwrap();


### PR DESCRIPTION
I've added a field named `_private` earlier on some stucts.
The goal was to foce library users to use the builder instead.

This was a paternalistic mistake
